### PR TITLE
Timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SRCS=\
 	src/Buffer.cpp \
 	src/BufferedSocket.cpp \
 	src/CommandEventHandler.cpp \
+	src/EventHandler.cpp \
 	src/Hash.cpp \
 	src/Logging.cpp \
 	src/PullFileEventHandler.cpp \

--- a/src/CommandEventHandler.cpp
+++ b/src/CommandEventHandler.cpp
@@ -42,6 +42,7 @@ CommandEventHandler::CommandLine::CommandLine(std::string line)
 CommandEventHandler::CommandEventHandler(PRFileDesc* socket)
   : mBufSocket(socket), mDataEventHandler(NULL), mPrompt("$>")
 {
+  registerWithReactor();
   sendPrompt();
 }
 

--- a/src/EventHandler.cpp
+++ b/src/EventHandler.cpp
@@ -1,0 +1,19 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "EventHandler.h"
+#include "Reactor.h"
+
+void
+EventHandler::registerWithReactor()
+{
+  Reactor::instance()->registerHandler(this);
+}
+
+
+void
+EventHandler::setTimeout(PRIntervalTime interval)
+{
+  Reactor::instance()->setTimeout(interval, this);
+}

--- a/src/EventHandler.h
+++ b/src/EventHandler.h
@@ -5,6 +5,7 @@
 #ifndef negatus_event_handler_h
 #define negatus_event_handler_h
 
+#include <prinrval.h>
 #include <prio.h>
 #include <prtime.h>
 #include <string>
@@ -17,17 +18,14 @@ public:
 
   virtual void close() { mClosed = true; }
   bool closed() { return mClosed; }
-  virtual void getPollDescs(std::vector<PRPollDesc>& descs) = 0;
-  PRTime getTimeout() { return mTimeout; }
+  virtual void getPollDescs(std::vector<PRPollDesc>& descs) {};
   virtual void handleEvent(PRPollDesc handle) {}
   virtual void handleTimeout() {}
   virtual std::string name() { return "EventHandler"; }
 
 protected:
-  void setTimeout(PRTime timeout) { mTimeout = timeout; }
-  void clearTimeout() { mTimeout = 0; }
-
-  PRTime mTimeout;
+  void registerWithReactor();
+  void setTimeout(PRIntervalTime interval);
 
 private:
   bool mClosed;

--- a/src/Reactor.h
+++ b/src/Reactor.h
@@ -5,6 +5,7 @@
 #ifndef negatus_reactor_h
 #define negatus_reactor_h
 
+#include <prinrval.h>
 #include <prio.h>
 #include <prtime.h>
 #include <vector>
@@ -15,15 +16,35 @@ class Reactor {
 public:
   Reactor();
 
+  /** Register an EventHandler with the Reactor.
+   * Registering causes the Reactor to call getPollDescs()
+   * on the handler and to delete the handler if it is
+   * closed.
+   * It is not necessary to register a handler in order
+   * to set a timeout unless automatic cleanup is desired.
+   * FIXME: is this weirdly asymmetric?
+   */
   void registerHandler(EventHandler* evtHandler);
   void removeHandler(EventHandler* evtHandler);
   void run();
   void stop();
 
+  void setTimeout(PRIntervalTime interval, EventHandler* evtHandler);
+
   static Reactor* instance();
 
 private:
+  struct Timeout
+  {
+    PRIntervalTime epoch;
+    PRIntervalTime interval;
+    EventHandler* evtHandler;
+
+    bool expired();
+  };
+
   std::vector<EventHandler*> mEvtHandlers;
+  std::vector<Timeout> mTimeouts;
   static Reactor* mInstance;
   void deleteClosed();
 };

--- a/src/SUTAgent.cpp
+++ b/src/SUTAgent.cpp
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 
   if (optionError)
     return 1;
-  
+
   SocketAcceptor* acceptor = new SocketAcceptor();
   PRNetAddr acceptorAddr;
   PR_InitializeNetAddr(PR_IpAddrAny, port, &acceptorAddr);
@@ -91,7 +91,9 @@ int main(int argc, char **argv)
     std::cerr << "Failure to open socket: " << PR_GetError() << std::endl;
     return 1;
   }
+
   Reactor* reactor = Reactor::instance();
+
   while (!wantToDie)
     reactor->run();
   reactor->stop();

--- a/src/SocketAcceptor.cpp
+++ b/src/SocketAcceptor.cpp
@@ -52,7 +52,7 @@ SocketAcceptor::listen(PRNetAddr addr)
     return status;
   status = PR_Listen(mSocket, 128);
   if (status == PR_SUCCESS)
-    Reactor::instance()->registerHandler(this);
+    registerWithReactor();
   return status;
 }
 
@@ -86,5 +86,4 @@ SocketAcceptor::handleEvent(PRPollDesc desc)
   sockOpt.value.non_blocking = PR_TRUE;
   PR_SetSocketOption(newSocket, &sockOpt);
   CommandEventHandler* handler = new CommandEventHandler(newSocket);
-  Reactor::instance()->registerHandler(handler);
 }


### PR DESCRIPTION
This adds timeout capabilities to the Reactor and EventHandlers. We'll be able to use this as a basis for asynchronous subprocess handling by periodically polling the subprocess until it exits.
