### PR TITLE
Add compiler-generated Makefile dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ busybox-armv6l*
 *.swp
 *.log
 *~
-
+.deps/

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ include Makefile.common
 $(AGENT): $(OBJS)
 	$(LD) -o $@ $(OBJS) $(LDFLAGS) $(LDLIBS)
 
-%.o: %.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
+$(OBJS): .deps/dir
+.deps/dir:
+	mkdir -p .deps
+	touch $@
 
+%.o: %.cpp
+	$(CC) $(CFLAGS) $(CPPFLAGS) -MD -MP -MF .deps/$(@F).pp -c $< -o $@
+
+deps = $(addprefix .deps/,$(addsuffix .pp,$(notdir $(OBJS))))
+
+-include $(deps)

--- a/Makefile.common
+++ b/Makefile.common
@@ -31,4 +31,4 @@ AGENT = agent$(EXE)
 all: $(AGENT)
 
 clean:
-	rm -f src/*$(OBJ) $(AGENT)
+	rm -rf src/*$(OBJ) $(AGENT) .deps


### PR DESCRIPTION
I hate this so much it hurts, but not having working dependencies makes me crazy.
