### PR TITLE
Mac build fix from Win32 port

### DIFF
--- a/src/Strings.h
+++ b/src/Strings.h
@@ -7,6 +7,7 @@
 
 #include <prio.h>
 #include <prtypes.h>
+#include <stdlib.h>
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
Missed a spot, this is needed to fix the Mac build.
