### PR TITLE
bug 1093810 - Make OS X builds work on 10.7 when compiled on 10.9

### DIFF
--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -8,6 +8,8 @@ LDFLAGS+=-arch i386
 CPPFLAGS=\
         -g \
         -arch i386 \
+        -mmacosx-version-min=10.7 \
+        -stdlib=libc++ \
         `/usr/local/bin/nspr-config --cflags`
 
 LDLIBS=`/usr/local/bin/nspr-config --libs`


### PR DESCRIPTION
Details: https://bugzilla.mozilla.org/show_bug.cgi?id=1093810#c1
