### PR TITLE
Build for mac 10 7

### DIFF
--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -5,13 +5,17 @@ CXX=g++
 LD:=$(CXX)
 LDFLAGS+=-arch i386
 
+ifndef NSPR
+NSPR=/usr/local
+endif
+
 CPPFLAGS=\
         -g \
         -arch i386 \
         -mmacosx-version-min=10.7 \
         -stdlib=libc++ \
-        `/usr/local/bin/nspr-config --cflags`
+        `$(NSPR)/bin/nspr-config --cflags`
 
-LDLIBS=`/usr/local/bin/nspr-config --libs`
+LDLIBS=`$(NSPR)/bin/nspr-config --libs`
 
 include Makefile

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -5,17 +5,13 @@ CXX=g++
 LD:=$(CXX)
 LDFLAGS+=-arch i386
 
-ifndef NSPR
-NSPR=/usr/local
-endif
-
 CPPFLAGS=\
         -g \
         -arch i386 \
         -mmacosx-version-min=10.7 \
         -stdlib=libc++ \
-        `$(NSPR)/bin/nspr-config --cflags`
+        `/usr/local/bin/nspr-config --cflags`
 
-LDLIBS=`$(NSPR)/bin/nspr-config --libs`
+LDLIBS=`/usr/local/bin/nspr-config --libs`
 
 include Makefile

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -3,7 +3,7 @@ CXX=g++
 # would have to replicate the link line that g++ uses.
 #LD=ld
 LD:=$(CXX)
-LDFLAGS+=-arch i386
+LDFLAGS+=-arch i386 -mmacosx-version-min=10.7 -stdlib=libc++
 
 CPPFLAGS=\
         -g \


### PR DESCRIPTION
Add flags to do proper linking for support for Mac OS X 10.7. Gets rid of illegal instruction error.